### PR TITLE
RDKUI-852: Correctly set language during FTI

### DIFF
--- a/accelerator-home-ui/settings.json
+++ b/accelerator-home-ui/settings.json
@@ -13,6 +13,6 @@
     "log": true,
     "enableAppSuspended": true,
     "showVersion": false,
-    "version": "4.7.18"
+    "version": "4.7.19"
   }
 }

--- a/accelerator-home-ui/src/screens/SplashScreens/LanguageScreen.js
+++ b/accelerator-home-ui/src/screens/SplashScreens/LanguageScreen.js
@@ -171,7 +171,9 @@ export default class LanguageScreen extends Lightning.Component {
         _handleEnter() {
           //need to verify
           if (Language.get() !== availableLanguages[this._Languages.tag('List').index]) {
-            this.updateUILanguage(this._Languages.tag('List').index)
+            const index = this._Languages.tag('List').index
+            localStorage.setItem('LanguageSelectedIndex', index)
+            this.updateUILanguage(index)
             let path = location.pathname.split('index.html')[0]
             let url = path.slice(-1) === '/' ? "static/loaderApp/index.html" : "/static/loaderApp/index.html"
             let notification_url = location.origin + path + url
@@ -211,7 +213,8 @@ export default class LanguageScreen extends Lightning.Component {
         }
 
         _handleEnter() {
-          this.updateUILanguage(this._Languages.tag('List').index)
+          const languageSelectedIndex = localStorage.getItem('LanguageSelectedIndex')
+          this.updateUILanguage(languageSelectedIndex ? languageSelectedIndex : 0)
           Router.navigate('splash/network')
         }
 


### PR DESCRIPTION
Previously, when index was being updated when user scrolled to "Continue". It caused to save Spanish language as selected, as it was most recently selected langauge.

Currently, an aditional variable is used as a localstorage that is updated on "enter". It is used to indicate what language was selected. If this is undefined, use 0 index which is the default. Localstorage is used to persist after page reload.